### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: Set up a Paylocity connector
 og:title: Set up a Paylocity connector - C1 docs
-og:description: Integrate your Paylocity instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
-description: C1 provides identity governance and just-in-time provisioning for Paylocity. Integrate your Paylocity instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.
+og:description: "C1 provides identity governance for Paylocity. Integrate your Paylocity instance with C1 for unified visibility and governance over user access."
+description: "C1 provides identity governance for Paylocity. Integrate your Paylocity instance with C1 for unified visibility and governance over user access."
 sidebarTitle: Paylocity
 ---
 
@@ -29,7 +29,7 @@ To set up the Paylocity connector, you'll need:
 * Company ID for the Paylocity entity you want to integrate with C1
 * Base API gateway URL of your Paylocity API environment
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the Paylocity connector
 
@@ -81,7 +81,7 @@ Click **Save**.
 The connector's label changes to **Syncing**, followed by **Connected**. You can view the logs to ensure that information is syncing.
 </Step>
 </Steps>
-**That's it!** Your Paylocity connector is now pulling access data into C1.
+**Done.** Your Paylocity connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 
@@ -199,7 +199,7 @@ Create a namespace in which to run C1 connectors (if desired), then apply the se
 Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the Paylocity connector to. Paylocity data should be found on the **Entitlements** and **Accounts** tabs.
 </Step>
 </Steps>
-**That's it!** Your Paylocity connector is now pulling access data into C1.
+**Done.** Your Paylocity connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines