### PR TITLE
fix: correct Paylocity employee sync (CXH-1409)

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -85,24 +85,18 @@ func (c *PaylocityClient) ListEmployees(ctx context.Context, options PageOptions
 	var res EmployeesResponse
 	endpointPath := fmt.Sprintf("/coreHr/v1/companies/%s/employees", c.companyID)
 
-	_, rl, err := c.doRequest(ctx, http.MethodGet, endpointPath, &res, nil, withLimitParam(options.Limit), withNextToken(options.PageToken))
+	limit := options.Limit
+	if limit <= 0 || limit > EmployeesMaxPageSize {
+		limit = EmployeesMaxPageSize
+	}
+
+	_, rl, err := c.doRequest(ctx, http.MethodGet, endpointPath, &res, nil,
+		withLimitParam(limit), withNextToken(options.PageToken), withIncludes("info", "position", "status"))
 	if err != nil {
 		return nil, "", rl, err
 	}
 
 	return res.Employees, res.NextToken, rl, nil
-}
-
-func (c *PaylocityClient) GetUserById(ctx context.Context, userId string) (*User, *v2.RateLimitDescription, error) {
-	var user User
-	endpointPath := fmt.Sprintf("/coreHr/v1/companies/%s/employees/%s", c.companyID, userId)
-
-	_, rl, err := c.doRequest(ctx, http.MethodGet, endpointPath, &user, nil, withIncludes("info", "position", "status"))
-	if err != nil {
-		return nil, rl, err
-	}
-
-	return &user, rl, nil
 }
 
 func (c *PaylocityClient) doRequest(ctx context.Context, method string, endpointPath string, target interface{}, body interface{}, opts ...ReqOpt) (*http.Header, *v2.RateLimitDescription, error) {

--- a/pkg/client/client_interface.go
+++ b/pkg/client/client_interface.go
@@ -9,5 +9,4 @@ import (
 type ClientService interface {
 	ListEmployees(ctx context.Context, options PageOptions) ([]*User, string, *v2.RateLimitDescription, error)
 	ListPositionCodes(ctx context.Context, options PageOptions) ([]*Position, string, *v2.RateLimitDescription, error)
-	GetUserById(ctx context.Context, userId string) (*User, *v2.RateLimitDescription, error)
 }

--- a/pkg/client/client_mock.go
+++ b/pkg/client/client_mock.go
@@ -9,7 +9,6 @@ import (
 type MockService struct {
 	ListEmployeesFunc     func(ctx context.Context, options PageOptions) ([]*User, string, *v2.RateLimitDescription, error)
 	ListPositionCodesFunc func(ctx context.Context, options PageOptions) ([]*Position, string, *v2.RateLimitDescription, error)
-	GetUserByIdFunc       func(ctx context.Context, userId string) (*User, *v2.RateLimitDescription, error)
 }
 
 func (m *MockService) ListEmployees(ctx context.Context, options PageOptions) ([]*User, string, *v2.RateLimitDescription, error) {
@@ -18,8 +17,4 @@ func (m *MockService) ListEmployees(ctx context.Context, options PageOptions) ([
 
 func (m *MockService) ListPositionCodes(ctx context.Context, options PageOptions) ([]*Position, string, *v2.RateLimitDescription, error) {
 	return m.ListPositionCodesFunc(ctx, options)
-}
-
-func (m *MockService) GetUserById(ctx context.Context, userId string) (*User, *v2.RateLimitDescription, error) {
-	return m.GetUserByIdFunc(ctx, userId)
 }

--- a/pkg/client/helpers.go
+++ b/pkg/client/helpers.go
@@ -8,6 +8,9 @@ import (
 
 const ItemsPerPage = 100
 
+// EmployeesMaxPageSize is the max limit accepted by the coreHr /employees endpoint.
+const EmployeesMaxPageSize = 20
+
 type ReqOpt func(reqURL *url.URL)
 
 type PageOptions struct {

--- a/pkg/client/models.go
+++ b/pkg/client/models.go
@@ -12,18 +12,23 @@ type EmployeesResponse struct {
 }
 
 type User struct {
-	ID          string          `json:"id"`
-	DisplayName string          `json:"displayName"`
-	Status      string          `json:"statusType"`
-	Info        InfoPayload     `json:"info"`
-	Position    PositionPayload `json:"position"`
+	ID            string          `json:"id"`
+	Info          InfoPayload     `json:"info"`
+	CurrentStatus StatusPayload   `json:"currentStatus"`
+	Position      PositionPayload `json:"position"`
 }
 
 type InfoPayload struct {
-	FirstName string `json:"firstName"`
-	LastName  string `json:"lastName"`
-	Email     string `json:"personalEmail"`
-	JobTitle  string `json:"jobTitle"`
+	FirstName   string `json:"firstName"`
+	LastName    string `json:"lastName"`
+	DisplayName string `json:"displayName"`
+	Email       string `json:"personalEmail"`
+	JobTitle    string `json:"jobTitle"`
+}
+
+type StatusPayload struct {
+	Status     string `json:"status"`
+	StatusType string `json:"statusType"`
 }
 
 type PositionPayload struct {

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -55,40 +55,34 @@ func (o *userBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *
 	return nil, "", nil, nil
 }
 
-// The Grants function for positions is implemented here on the userBuilder for performance reasons.
-// This allows assigning grants directly while iterating through users, as the Paylocity API
-// already includes the 'positionCode' in the employee list, avoiding the need to iterate
-// over all positions to resolve each user's assignment individually.
-func (o *userBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	userId := resource.Id.Resource
-	outputAnnotations := annotations.New()
-
-	user, rateLimitDesc, err := o.client.GetUserById(ctx, userId)
-	if rateLimitDesc != nil {
-		outputAnnotations.WithRateLimiting(rateLimitDesc)
-	}
+// Position membership is granted here on the userBuilder: the employee list embeds positionCode
+// into each user resource, so we read it back from the synced resource instead of re-fetching.
+func (o *userBuilder) Grants(_ context.Context, userResource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+	userTrait, err := resource.GetUserTrait(userResource)
 	if err != nil {
-		return nil, "", outputAnnotations, fmt.Errorf("failed to get user %s for grants: %w", userId, err)
+		return nil, "", nil, fmt.Errorf("failed to read user trait for %s: %w", userResource.Id.Resource, err)
 	}
 
-	var grants []*v2.Grant
-	if user.Position.PositionCode != "" {
-		positionResource := &v2.Resource{
-			Id: &v2.ResourceId{
-				ResourceType: positionResourceType.Id,
-				Resource:     user.Position.PositionCode,
-			},
-		}
-		grants = append(grants, grant.NewGrant(positionResource, PermissionMember, resource.Id))
+	positionCode, ok := resource.GetProfileStringValue(userTrait.GetProfile(), "position_code")
+	if !ok || positionCode == "" {
+		return nil, "", nil, nil
 	}
 
-	return grants, "", outputAnnotations, nil
+	positionResource := &v2.Resource{
+		Id: &v2.ResourceId{
+			ResourceType: positionResourceType.Id,
+			Resource:     positionCode,
+		},
+	}
+
+	grants := []*v2.Grant{grant.NewGrant(positionResource, PermissionMember, userResource.Id)}
+	return grants, "", nil, nil
 }
 
 func parseUserToResource(user *client.User, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
 	profile := map[string]interface{}{
 		"user_id":       user.ID,
-		"display_name":  user.DisplayName,
+		"display_name":  user.Info.DisplayName,
 		"first_name":    user.Info.FirstName,
 		"last_name":     user.Info.LastName,
 		"job_title":     user.Info.JobTitle,
@@ -98,7 +92,7 @@ func parseUserToResource(user *client.User, parentResourceID *v2.ResourceId) (*v
 	}
 
 	var status v2.UserTrait_Status_Status
-	normalizedStatus := strings.ToLower(user.Status)
+	normalizedStatus := strings.ToLower(user.CurrentStatus.Status)
 	switch normalizedStatus {
 	case "active":
 		status = v2.UserTrait_Status_STATUS_ENABLED
@@ -114,7 +108,7 @@ func parseUserToResource(user *client.User, parentResourceID *v2.ResourceId) (*v
 	}
 
 	userResource, err := resource.NewUserResource(
-		user.DisplayName,
+		user.Info.DisplayName,
 		userResourceType,
 		user.ID,
 		userTraitOptions,

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -25,10 +25,9 @@ func TestUserList(t *testing.T) {
 	ctx := context.Background()
 
 	mockUser1 := &client.User{
-		ID:          "101",
-		DisplayName: "Ana Gomez",
-		Status:      "Active",
-		Info:        client.InfoPayload{Email: "ana.gomez@example.com"},
+		ID:            "101",
+		Info:          client.InfoPayload{DisplayName: "Ana Gomez", Email: "ana.gomez@example.com"},
+		CurrentStatus: client.StatusPayload{Status: "Active"},
 	}
 
 	t.Run("should list users successfully", func(t *testing.T) {
@@ -49,7 +48,7 @@ func TestUserList(t *testing.T) {
 	t.Run("should paginate correctly", func(t *testing.T) {
 		// Arrange
 		userBuilder, mockClientService := newTestUserBuilder()
-		mockUser2 := &client.User{ID: "102", DisplayName: "Juan Perez"}
+		mockUser2 := &client.User{ID: "102", Info: client.InfoPayload{DisplayName: "Juan Perez"}}
 
 		callCount := 0
 		mockClientService.ListEmployeesFunc = func(ctx context.Context, options client.PageOptions) ([]*client.User, string, *v2.RateLimitDescription, error) {
@@ -101,61 +100,35 @@ func TestUserList(t *testing.T) {
 
 func TestUserGrants(t *testing.T) {
 	ctx := context.Background()
-	userResource := &v2.Resource{
-		Id: &v2.ResourceId{ResourceType: userResourceType.Id, Resource: "101"},
-	}
-	mockUser := &client.User{
-		ID:       "101",
-		Position: client.PositionPayload{PositionCode: "DEV-01"},
-	}
 
 	t.Run("should return grant for user with position", func(t *testing.T) {
-		// Arrange
-		userBuilder, mockClientService := newTestUserBuilder()
-		mockClientService.GetUserByIdFunc = func(ctx context.Context, employeeID string) (*client.User, *v2.RateLimitDescription, error) {
-			return mockUser, nil, nil
-		}
+		userBuilder, _ := newTestUserBuilder()
+		userResource, err := parseUserToResource(&client.User{
+			ID:       "101",
+			Info:     client.InfoPayload{DisplayName: "Ana Gomez"},
+			Position: client.PositionPayload{PositionCode: "DEV-01"},
+		}, nil)
+		require.NoError(t, err)
 
-		// Act
 		grants, _, _, err := userBuilder.Grants(ctx, userResource, &pagination.Token{})
 
-		// Assert
 		require.NoError(t, err)
 		require.Len(t, grants, 1)
 		require.Equal(t, "DEV-01", grants[0].Entitlement.Resource.Id.Resource)
 		require.Equal(t, "101", grants[0].Principal.Id.Resource)
 	})
 
-	t.Run("should return error if GetUserById fails", func(t *testing.T) {
-		// Arrange
-		userBuilder, mockClientService := newTestUserBuilder()
-		mockClientService.GetUserByIdFunc = func(ctx context.Context, employeeID string) (*client.User, *v2.RateLimitDescription, error) {
-			return nil, nil, fmt.Errorf("user not found")
-		}
+	t.Run("should return no grants for user without position", func(t *testing.T) {
+		userBuilder, _ := newTestUserBuilder()
+		userResource, err := parseUserToResource(&client.User{
+			ID:   "P1",
+			Info: client.InfoPayload{DisplayName: "Administrator"},
+		}, nil)
+		require.NoError(t, err)
 
-		_, _, _, err := userBuilder.Grants(ctx, userResource, &pagination.Token{})
+		grants, _, _, err := userBuilder.Grants(ctx, userResource, &pagination.Token{})
 
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to get user 101 for grants: user not found")
-	})
-
-	t.Run("should handle rate limit on GetUserById", func(t *testing.T) {
-		// Arrange
-		userBuilder, mockClientService := newTestUserBuilder()
-		expectedReset := time.Now().Add(15 * time.Second)
-		mockClientService.GetUserByIdFunc = func(ctx context.Context, employeeID string) (*client.User, *v2.RateLimitDescription, error) {
-			return nil, &v2.RateLimitDescription{ResetAt: timestamppb.New(expectedReset)}, fmt.Errorf("rate limited")
-		}
-
-		_, _, annotations, err := userBuilder.Grants(ctx, userResource, &pagination.Token{})
-
-		require.Error(t, err)
-		require.NotNil(t, annotations)
-
-		rateLimitAnn := &v2.RateLimitDescription{}
-		ok, pickErr := annotations.Pick(rateLimitAnn)
-		require.NoError(t, pickErr)
-		require.True(t, ok, "rate limit annotation should be present")
-		require.Equal(t, expectedReset.Unix(), rateLimitAnn.ResetAt.Seconds)
+		require.NoError(t, err)
+		require.Empty(t, grants)
 	})
 }


### PR DESCRIPTION
## What

Fixes employee sync bugs found during NextGen sandbox validation (347766RCU).

- **Page size**: clamp coreHr employees to 20; the endpoint caps at 20 and `limit=100` returned HTTP 400.
- **Position/info sourcing**: request `include=info,position,status` on the employee list and read position/email/status from the synced resource. Drops the per-user `GetUserById` in `Grants`, which 404'd on position-less/system records and aborted the sync.
- Side effects of the above: emails were always empty (info never requested) and status mapping marked all users disabled — both now correct.

## Validation

Live against NextGen sandbox 347766RCU: 65 users, 54 position grants, 11 position-less accounts correctly skipped, no 404s, emails 50/65, status 44 enabled / 21 disabled. `go build` + `go test` green.

Closes CXH-1409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)