### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/positions.go
+++ b/pkg/connector/positions.go
@@ -80,9 +80,7 @@ func parsePositionToResource(position *client.Position, parentResourceID *v2.Res
 		"closed_date":    position.ClosedDate.Format(time.RFC3339),
 	}
 
-	positionTraitOptions := []resource.RoleTraitOption{
-		resource.WithRoleProfile(profile),
-	}
+	positionTraitOptions := []resource.RoleTraitOption{}
 
 	positionResource, err := resource.NewRoleResource(
 		position.Title,
@@ -90,6 +88,7 @@ func parsePositionToResource(position *client.Position, parentResourceID *v2.Res
 		position.Code,
 		positionTraitOptions,
 		resource.WithParentResourceID(parentResourceID),
+		resource.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -58,12 +58,7 @@ func (o *userBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *
 // Position membership is granted here on the userBuilder: the employee list embeds positionCode
 // into each user resource, so we read it back from the synced resource instead of re-fetching.
 func (o *userBuilder) Grants(_ context.Context, userResource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	userTrait, err := resource.GetUserTrait(userResource)
-	if err != nil {
-		return nil, "", nil, fmt.Errorf("failed to read user trait for %s: %w", userResource.Id.Resource, err)
-	}
-
-	positionCode, ok := resource.GetProfileStringValue(userTrait.GetProfile(), "position_code")
+	positionCode, ok := resource.GetProfileStringValue(resource.GetProfile(userResource), "position_code")
 	if !ok || positionCode == "" {
 		return nil, "", nil, nil
 	}
@@ -103,8 +98,6 @@ func parseUserToResource(user *client.User, parentResourceID *v2.ResourceId) (*v
 	userTraitOptions := []resource.UserTraitOption{
 		resource.WithEmail(user.Info.Email, true),
 		resource.WithUserLogin(user.Info.Email),
-		resource.WithStatus(status),
-		resource.WithUserProfile(profile),
 	}
 
 	userResource, err := resource.NewUserResource(
@@ -113,6 +106,8 @@ func parseUserToResource(user *client.User, parentResourceID *v2.ResourceId) (*v
 		user.ID,
 		userTraitOptions,
 		resource.WithParentResourceID(parentResourceID),
+		resource.WithResourceProfile(profile),
+		resource.WithResourceStatus(v2.Status_ResourceStatus(status), ""),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
